### PR TITLE
Remove link to SIMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This repository provides technical guidance for users and developers using insta
 # Contents
 * [Transitioning to Ampere processors](#transitioning-to-graviton)
 * [Optimizing for Ampere processors](optimizing.md)
-* [Taking advantage of Arm Advanced SIMD instructions](SIMD_and_vectorization.md)
 * [Recent software updates relevant to Ampere processors](#recent-software-updates-relevant-to-graviton)
 * Language-specific considerations
 	* [C/C++](c-c++.md)


### PR DESCRIPTION
Simplifying README.md by removing link to SIMD and vector extensions instructions for Graviton. We may add back information on SIMD and vector extensions later, but they are not a part of our immediate scope.